### PR TITLE
small fix in global css without it all dimentions fucked up

### DIFF
--- a/src/app/[locale]/globals.css
+++ b/src/app/[locale]/globals.css
@@ -83,6 +83,7 @@
 
 :root {
   --font-montserrat: 'Montserrat', sans-serif;
+  --font-size: 16px;
 
   --background: #f1f1f1;
   --background-secondary: #303030;
@@ -150,6 +151,10 @@
     radial-gradient(circle, rgba(26, 211, 170, 0.1) 2px, transparent 2px),
     linear-gradient(0deg, #0a6f3c, #0a6f3c);
 }
+html {
+  font-size: var(--font-size);
+}
+
 
 .montserrat {
   font-family: var(--font-montserrat);


### PR DESCRIPTION
This pull request introduces a small enhancement to the global CSS styles by standardizing font size through the use of a CSS variable.

Styling updates:

* `src/app/[locale]/globals.css`: Added a `--font-size` variable to the `:root` selector and applied it to the `html` element to standardize font sizing across the application. ([src/app/[locale]/globals.cssR86](diffhunk://#diff-5f047c49cd3fd157c2bf6ca28b53ac906658807026961fec48c7e27d3035c1f7R86), [src/app/[locale]/globals.cssR154-R157](diffhunk://#diff-5f047c49cd3fd157c2bf6ca28b53ac906658807026961fec48c7e27d3035c1f7R154-R157))