### PR TITLE
Refactor: Use consistent API fetching with fetchFromApi

### DIFF
--- a/src/services/contactsService.ts
+++ b/src/services/contactsService.ts
@@ -1,9 +1,12 @@
-import api from '@/lib/api';
+import { fetchFromApi } from '@/lib/apiFetcher';
 import { ContactFormData, ContactResponse } from '@/types/contact';
 
 export const sendContact = async (
   formData: ContactFormData
 ): Promise<ContactResponse> => {
-  const response = await api.guest.post<ContactResponse>('/contact', formData);
-  return response.data;
+  const response = await fetchFromApi<ContactResponse>('/contact', {
+    method: 'POST',
+    data: formData,
+  });
+  return response;
 };

--- a/src/services/newsService.ts
+++ b/src/services/newsService.ts
@@ -1,4 +1,4 @@
-import api from '@/lib/api';
+import { fetchFromApi } from '@/lib/apiFetcher';
 import {
   INewsItem,
   INewsItemApiResponse,
@@ -7,24 +7,26 @@ import {
 } from '@/types';
 
 export const getNews = async (locale: Tlocale): Promise<INewsItem[]> => {
-  const response = await api.guest.get<INewsListApiResponse>('/posts', {
+  const response = await fetchFromApi<INewsListApiResponse>('/posts', {
+    method: 'GET',
     params: {
       lang: locale,
     },
   });
-  return response.data?.data?.posts ?? [];
+  return response.data?.posts ?? [];
 };
 
 export const getNewsById = async (
   id: string | number,
   locale: string
 ): Promise<INewsItem> => {
-  const response = await api.guest.get<INewsItemApiResponse>(`/posts/${id}`, {
+  const response = await fetchFromApi<INewsItemApiResponse>(`/posts/${id}`, {
+    method: 'GET',
     params: {
       lang: locale,
     },
   });
-  const { post } = response.data.data;
+  const { post } = response.data;
 
   if (!post) throw new Error('News item not found in API response.');
 


### PR DESCRIPTION
Changed API calls in services (posts and contacts) to use `fetchFromApi`.